### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Usage Example
     display = adafruit_displayio_sh1106.SH1106(display_bus, width=WIDTH, height=HEIGHT)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(WIDTH, HEIGHT, 1)

--- a/examples/displayio_sh1106_simpletest.py
+++ b/examples/displayio_sh1106_simpletest.py
@@ -27,7 +27,7 @@ BORDER = 5
 display = adafruit_displayio_sh1106.SH1106(display_bus, width=WIDTH, height=HEIGHT)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(WIDTH, HEIGHT, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a SH1106 display to test with.