### PR TITLE
Fix type casing

### DIFF
--- a/adafruit_displayio_sh1106.py
+++ b/adafruit_displayio_sh1106.py
@@ -62,7 +62,7 @@ class SH1106(displayio.Display):
     :param int rotation: The rotation of the display. 0, 90, 180 or 270.
     """
 
-    def __init__(self, bus: displayio.Fourwire, **kwargs) -> None:
+    def __init__(self, bus: displayio.FourWire, **kwargs) -> None:
         init_sequence = bytearray(_INIT_SEQUENCE)
         super().__init__(
             bus,


### PR DESCRIPTION
This is the same issue as found and addressed in [this PR](https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SSD1306/pull/29).

This PR fixes a type casing issue that prevents instantiation of the `SSD1306` object. The constructor expects a type of `displayio.Fourwire` but the 'w' should be capitalized such that the expected type is `displayio.FourWire`.

The block below is a snippet of the output from a CI/CD runner attempting to build a project which references this SSD1306 repo. Because of the lowercase 'w', the project fails to find the named type, and the code fails.

```
ImportError: Failed to import test module: test.test_adjust
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/unittest/loader.py", line 407, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/unittest/loader.py", line 350, in _get_module_from_name
    __import__(name)
  File "/builds/project-40/test/test_adjust.py", line 3, in <module>
    from fruity_menu.adjust import AdjustMenu, BoolMenu
  File "/builds/project-40/fruity_menu/adjust.py", line 4, in <module>
    from adafruit_displayio_sh1106 import SH1106
  File "/builds/project-40/env/lib/python3.11/site-packages/adafruit_displayio_sh1106.py", line 55, in <module>
    class SH1106(displayio.Display):
  File "/builds/project-40/env/lib/python3.11/site-packages/adafruit_displayio_sh1106.py", line 65, in SH1106
    def __init__(self, bus: displayio.Fourwire, **kwargs) -> None:
                            ^^^^^^^^^^^^^^^^^^
AttributeError: module 'displayio' has no attribute 'Fourwire'
```