### PR TITLE
Fixes issue 17 - sleep() throws error

### DIFF
--- a/adafruit_displayio_sh1106.py
+++ b/adafruit_displayio_sh1106.py
@@ -108,7 +108,7 @@ class SH1106(BusDisplay):
             4) The MP can access (update) the built-in display RAM
         """
         if self._is_awake:
-            self.bus.send(0xAE, [0x00])  # 0xAE = display off, sleep mode
+            self.bus.send(0xAE, [])  # 0xAE = display off, sleep mode
             self._is_awake = False
 
     def wake(self) -> None:
@@ -116,5 +116,5 @@ class SH1106(BusDisplay):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            self.bus.send(0xAF, [0x00])  # 0xAF = display on
+            self.bus.send(0xAF, [])  # 0xAF = display on
             self._is_awake = True

--- a/adafruit_displayio_sh1106.py
+++ b/adafruit_displayio_sh1106.py
@@ -108,7 +108,7 @@ class SH1106(BusDisplay):
             4) The MP can access (update) the built-in display RAM
         """
         if self._is_awake:
-            self.bus.send(0xAE, b"")  # 0xAE = display off, sleep mode
+            self.bus.send(0xAE, [0x00])  # 0xAE = display off, sleep mode
             self._is_awake = False
 
     def wake(self) -> None:
@@ -116,5 +116,5 @@ class SH1106(BusDisplay):
         Wake display from sleep mode
         """
         if not self._is_awake:
-            self.bus.send(0xAF, b"")  # 0xAF = display on
+            self.bus.send(0xAF, [0x00])  # 0xAF = display on
             self._is_awake = True


### PR DESCRIPTION
b"" does not pass properly to the i2cdisplay function as it tries to concatenate a list with a byte string.